### PR TITLE
Fix running heroku cli on non-1.9.3 ruby

### DIFF
--- a/lib/letsencrypt_heroku/tools.rb
+++ b/lib/letsencrypt_heroku/tools.rb
@@ -27,7 +27,7 @@ module LetsencryptHeroku
 
     def execute(command)
       log command
-      Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
+      Open3.popen3("unset RUBYOPT; #{command}") do |stdin, stdout, stderr, wait_thr|
         out, err = stdout.read, stderr.read
         log out
         log err


### PR DESCRIPTION
When using different ruby version than heroku cli does (1.9.3 at the time of this commit), running any heroku command fails.

Solution lifted from https://github.com/KMarshland/heroku-ssl/commit/5455c2a4ac3734b8d2395bab3f1529f8744bb741