### PR TITLE
Add FileUtils require

### DIFF
--- a/lib/letsencrypt_heroku/process/update_certificates.rb
+++ b/lib/letsencrypt_heroku/process/update_certificates.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 class LetsencryptHeroku::Process
   class UpdateCertificates
     include LetsencryptHeroku::Tools


### PR DESCRIPTION
Allows for a standalone usage (i.e. outside Rails apps)