### PR TITLE
Return failure status on error.

### DIFF
--- a/lib/letsencrypt_heroku/tools.rb
+++ b/lib/letsencrypt_heroku/tools.rb
@@ -11,7 +11,7 @@ module LetsencryptHeroku
       block.call
       @_spinner.success
     rescue LetsencryptHeroku::TaskError
-      exit
+      exit false
     end
 
     def log(message, level: :info)


### PR DESCRIPTION
Allows for a proper chaining in a shell script, e.g.

```shell
bundle exec letsencrypt_heroku && osascript -e 'display notification "Certificates updated" with title "Letsencrypt"'
```