### PR TITLE
Add keep_certs config option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Each block in this configuration will issue a new certificate, so if you need to
   heroku_app: stg-example-dev-application
 ```
 
+You can add `keep_certs: true` to a block if you need to keep the generated certificate.
+
 Please note that your application will be restarted for every single domain in your config. The restart happens automatically when the heroku challenge response gets set as environment variable.
 
 

--- a/lib/letsencrypt_heroku/process/update_certificates.rb
+++ b/lib/letsencrypt_heroku/process/update_certificates.rb
@@ -8,15 +8,20 @@ class LetsencryptHeroku::Process
       output 'Update certificates' do
         csr = Acme::Client::CertificateRequest.new(names: context.config.domains)
         certificate = context.client.new_certificate(csr)
-        File.write('privkey.pem', certificate.request.private_key.to_pem)
-        File.write('fullchain.pem', certificate.fullchain_to_pem)
+        privkey_name = "privkey_#{herokuapp}.pem"
+        fullchain_name = "fullchain_#{herokuapp}.pem"
+        File.write(privkey_name, certificate.request.private_key.to_pem)
+        File.write(fullchain_name, certificate.fullchain_to_pem)
 
         if has_already_cert(herokuapp)
-          execute "heroku certs:update fullchain.pem privkey.pem --confirm #{herokuapp} --app #{herokuapp}"
+          execute "heroku certs:update #{fullchain_name} #{privkey_name} --confirm #{herokuapp} --app #{herokuapp}"
         else
-          execute "heroku certs:add fullchain.pem privkey.pem --app #{herokuapp}"
+          execute "heroku certs:add #{fullchain_name} #{privkey_name} --app #{herokuapp}"
         end
-        FileUtils.rm %w(privkey.pem fullchain.pem)
+
+        unless context.config.keep_certs
+          FileUtils.rm [privkey_name, fullchain_name]
+        end
       end
       puts # finish the output with a nice newline ;)
     end


### PR DESCRIPTION
Here's the use case:

I'm generating a certificate for a domain that is used solely in the development (`localhost.domain.com`). The config looks like this:

```yml
- contact: email@domain.com
  domains: domain.com www.domain.com
  heroku_app: production-app

- contact: email@domain.com
  domains: staging.domain.com localhost.domain.com
  heroku_app: staging-app
  keep_certs: true
```

With this change, after generating certs, I have the staging/localhost certificates saved locally (in `localhost.domain.com.key` and `localhost.domain.com.crt`), so I can use them in development servers.