### PR TITLE
Lock acme-client version to 1.x

### DIFF
--- a/letsencrypt_heroku.gemspec
+++ b/letsencrypt_heroku.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   << 'letsencrypt_heroku'
 
   spec.add_dependency 'rainbow'
-  spec.add_dependency 'acme-client'
+  spec.add_dependency 'acme-client', '~> 1.0.0'
   spec.add_dependency 'tty-spinner'
   spec.add_dependency 'slop'
 


### PR DESCRIPTION
Since incompatible acme-client v2 has been released, updating gems breaks this gem. This PR locks its version to 1.x.