### PR TITLE
Increase wait time between response tests.

### DIFF
--- a/lib/letsencrypt_heroku/process/authorize_domains.rb
+++ b/lib/letsencrypt_heroku/process/authorize_domains.rb
@@ -30,7 +30,7 @@ class LetsencryptHeroku::Process
       while answer != challenge.file_content
         error('failed test response') if fail_count > 30
         fail_count += 1
-        sleep(1)
+        sleep(5)
         answer = `curl -sL #{url}`
       end
     end


### PR DESCRIPTION
This PR increases wait time between response tests from 1s to 5s. Since it retries 30 times it effectively only ran for max 30s, in which time dyno had to be restarted, so on slower apps it would time out.